### PR TITLE
Chat -fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,8 @@ A script for dawn of the dragons, that works based on data provided to https://d
 [![Code Climate](https://codeclimate.com/github/Idrinth/IDotD/badges/gpa.svg)](https://codeclimate.com/github/Idrinth/IDotD)
 [![Issue Count](https://codeclimate.com/github/Idrinth/IDotD/badges/issue_count.svg)](https://codeclimate.com/github/Idrinth/IDotD)
 
+We support Opera, Firefox and Chrome. Please make sure to update your installation of those on a regular basis, since we can't guarantee, that the script will work on outdated versions.
+
 # Bugs, desired Features etc.
 
 We prefer the usage of the [tracker](https://github.com/Idrinth/IDotD/issues) here, otherwise we do import requests from [GoogleDocs](https://docs.google.com/document/d/1ozOWQuAEKCNnt2cwQ4SZtkpYM_pvrl8Bnj0e_O1KKWs/edit) from time to time.

--- a/src/mods/chat.js
+++ b/src/mods/chat.js
@@ -299,9 +299,14 @@ idrinth.chat = {
                     };
                     var notify = function ( message, own, chatId ) {
                         var notActive = function ( chatId ) {
-                            return !idrinth.windowactive ||
-                                    !( document.getElementById ( 'idrinth-chat-tab-click-' + chatId ).getAttribute ( 'class' ) ).match ( /(\s|^)active( |$)/ ) ||
-                                    !( document.getElementById ( 'idrinth-chat' ).getAttribute ( 'class' ) ).match ( /(\s|^)active( |$)/ )
+                            try {
+                                return !idrinth.windowactive ||
+                                        !( document.getElementById ( 'idrinth-chat-tab-click-' + chatId ).getAttribute ( 'class' ) ).match ( /(\s|^)active( |$)/ ) ||
+                                        !( document.getElementById ( 'idrinth-chat' ).getAttribute ( 'class' ) ).match ( /(\s|^)active( |$)/ );
+                            } catch ( e ) {
+                                idrinth.core.log ( e.getMessage );
+                                return true;
+                            }
                         };
                         var messageAllowed = function ( text ) {
                             return ( idrinth.settings.notification.message && text.match ( /\{[A-Z]{2}-Raid / ) === null ) ||

--- a/src/mods/chat.js
+++ b/src/mods/chat.js
@@ -194,7 +194,7 @@ idrinth.chat = {
             var matches = message.match ( regex );
             var text = ( message.replace ( regex, '$1########$' + lastField ) ).split ( '########' );
             var textcontent = [ ];
-            var length = matches.length + text.length;
+            var length = ( matches && Array.isArray ( matches ) ? matches.length : 0 ) + ( text && Array.isArray ( text ) ? text.length : 0 );
             for (var count = 0; count < length; count++) {
                 textcontent = partHandler ( count, callbacks, text, textcontent );
             }

--- a/src/mods/chat.js
+++ b/src/mods/chat.js
@@ -309,9 +309,14 @@ idrinth.chat = {
                             }
                         };
                         var messageAllowed = function ( text ) {
-                            return ( idrinth.settings.notification.message && text.match ( /\{[A-Z]{2}-Raid / ) === null ) ||
-                                    ( idrinth.settings.notification.mention && text.match ( new RegExp ( '(\s|^)' + idrinth.core.escapeRegExp ( idrinth.chat.users[idrinth.chat.self].name ) + '(\s|$)', 'i' ) ) !== null ) ||
-                                    ( idrinth.settings.notification.raid && text.match ( /\{[A-Z]{2}-Raid / ) !== null )
+                            try {
+                                return ( idrinth.settings.notification.message && text.match ( /\{[A-Z]{2}-Raid / ) === null ) ||
+                                        ( idrinth.settings.notification.mention && text.match ( new RegExp ( '(\s|^)' + idrinth.core.escapeRegExp ( idrinth.chat.users[idrinth.chat.self].name ) + '(\s|$)', 'i' ) ) !== null ) ||
+                                        ( idrinth.settings.notification.raid && text.match ( /\{[A-Z]{2}-Raid / ) !== null );
+                            } catch ( e ) {
+                                idrinth.core.log ( e.getMessage ( ) );
+                                return false;
+                            }
                         };
                         if ( !own && notActive ( chatId ) && messageAllowed ( message.text ) ) {
                             try {

--- a/src/mods/core.js
+++ b/src/mods/core.js
@@ -23,6 +23,7 @@ idrinth.core = {
                     try {
                         return func ( value );
                     } catch ( e ) {
+                        idrinth.core.log ( e.getMessage () );
                         return null;
                     }
                 };


### PR DESCRIPTION
Chat messages were not corretly handled, leading to errors, when there were no matches for actual text found while appliing rules for more specialised text.
